### PR TITLE
WIP: Sidebar

### DIFF
--- a/main/fstreeitem.go
+++ b/main/fstreeitem.go
@@ -80,5 +80,9 @@ func (f *FSTreeItem) Click() {
 }
 
 func (f *FSTreeItem) SetVisible(vis bool) {
-	fmt.Println("Visible: ", f.name, vis)
+	// fmt.Println("Visible: ", f.name, vis)
+}
+
+func (f *FSTreeItem) SetExpanded(vis bool) {
+	// fmt.Println("Expanded: ", f.name, vis)
 }

--- a/main/fstreeitem.go
+++ b/main/fstreeitem.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Filesystem tree item
+
+type FSTreeItem struct {
+	TreeListItemImpl
+	path  string
+	name  string
+	isDir bool
+}
+
+type ByNameFoldersFirst []FSTreeItem
+
+func (a ByNameFoldersFirst) Len() int      { return len(a) }
+func (a ByNameFoldersFirst) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByNameFoldersFirst) Less(i, j int) bool {
+	if a[i].isDir != a[j].isDir {
+		return a[i].isDir
+	}
+	return a[i].name < a[j].name
+}
+
+var _ TreeListItem = &FSTreeItem{}
+
+func (f *FSTreeItem) Text() string {
+	return f.name
+}
+
+func (f *FSTreeItem) Type() string {
+	return "file"
+}
+
+func (f *FSTreeItem) Icon() string {
+	return ""
+}
+
+func (f *FSTreeItem) HasChildren() bool {
+	return f.isDir
+}
+
+func (f *FSTreeItem) Children() []TreeListItem {
+	file, err := os.Open(f.path)
+	if err != nil {
+		log.Printf("Error opening dir %#v: %s", f.path, err)
+		return nil
+	}
+	defer file.Close()
+
+	files, err := file.Readdir(-1)
+	if err != nil {
+		log.Printf("Error retreiving children of %#v: %s", f.path, err)
+	}
+
+	items := make([]TreeListItem, len(files))
+	store := make([]FSTreeItem, len(files))
+	for i, fx := range files {
+		store[i] = FSTreeItem{
+			path:  filepath.Join(f.path, fx.Name()),
+			name:  fx.Name(),
+			isDir: fx.IsDir(),
+		}
+		items[i] = &store[i]
+	}
+
+	sort.Sort(ByNameFoldersFirst(store)) // items pointers won't change
+
+	return items
+}
+
+func (f *FSTreeItem) Click() {
+	fmt.Println("Click: ", f.name)
+}
+
+func (f *FSTreeItem) SetVisible(vis bool) {
+	fmt.Println("Visible: ", f.name, vis)
+}

--- a/main/headeritem.go
+++ b/main/headeritem.go
@@ -1,0 +1,53 @@
+package main
+
+type HeaderItem struct {
+	TreeListItemImpl
+	name    string
+	isChild bool
+}
+
+func (f *HeaderItem) Text() string {
+	return f.name
+}
+
+func (f *HeaderItem) Type() string {
+	return "header"
+}
+
+func (f *HeaderItem) Click() {
+
+}
+
+//
+// func (f *FSTreeItem) HasChildren() bool {
+// 	return f.isDir
+// }
+//
+// func (f *FSTreeItem) Children() []TreeListItem {
+// 	file, err := os.Open(f.path)
+// 	if err != nil {
+// 		log.Printf("Error opening dir %#v: %s", f.path, err)
+// 		return nil
+// 	}
+// 	defer file.Close()
+//
+// 	files, err := file.Readdir(-1)
+// 	if err != nil {
+// 		log.Printf("Error retreiving children of %#v: %s", f.path, err)
+// 	}
+//
+// 	items := make([]TreeListItem, len(files))
+// 	store := make([]FSTreeItem, len(files))
+// 	for i, fx := range files {
+// 		store[i] = FSTreeItem{
+// 			path:  filepath.Join(f.path, fx.Name()),
+// 			name:  fx.Name(),
+// 			isDir: fx.IsDir(),
+// 		}
+// 		items[i] = &store[i]
+// 	}
+//
+// 	sort.Sort(ByNameFoldersFirst(store)) // items pointers won't change
+//
+// 	return items
+// }

--- a/main/projfolderitem.go
+++ b/main/projfolderitem.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/limetext/backend"
+	"github.com/ryanuber/go-glob"
+)
+
+// Filesystem tree item
+
+type ProjFolderItem struct {
+	TreeListItemImpl
+	path string
+	name string
+
+	projFolder *backend.Folder
+}
+
+type ByNameFoldersFirst2 []TreeListItem
+
+func (a ByNameFoldersFirst2) Len() int      { return len(a) }
+func (a ByNameFoldersFirst2) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ByNameFoldersFirst2) Less(i, j int) bool {
+	if a[i].HasChildren() != a[j].HasChildren() {
+		return a[i].HasChildren()
+	}
+	return a[i].Text() < a[j].Text()
+}
+
+var _ TreeListItem = &ProjFolderItem{}
+
+func (f *ProjFolderItem) Text() string {
+	return f.name
+}
+
+func (f *ProjFolderItem) Type() string {
+	return "file"
+}
+
+func (f *ProjFolderItem) Icon() string {
+	return ""
+}
+
+func (f *ProjFolderItem) HasChildren() bool {
+	return true
+}
+
+func (f *ProjFolderItem) Children() []TreeListItem {
+	file, err := os.Open(f.path)
+	if err != nil {
+		log.Printf("Error opening dir %#v: %s", f.path, err)
+		return nil
+	}
+	defer file.Close()
+
+	files, err := file.Readdir(-1)
+	if err != nil {
+		log.Printf("Error retreiving children of %#v: %s", f.path, err)
+	}
+
+	items := make([]TreeListItem, 0, len(files)/2)
+	for _, fx := range files {
+		path := filepath.Join(f.path, fx.Name())
+		if fx.IsDir() {
+			if !f.isIncluded(path+"/", f.projFolder.IncludePatterns, f.projFolder.ExcludePatterns) {
+				continue
+			}
+			items = append(items, &ProjFolderItem{
+				path:       path,
+				name:       fx.Name(),
+				projFolder: f.projFolder,
+			})
+		} else {
+			if !f.isIncluded(fx.Name(), f.projFolder.FileIncludePatterns, f.projFolder.FileExcludePatterns) {
+				continue
+			}
+			items = append(items, &FSTreeItem{
+				path:  path,
+				name:  fx.Name(),
+				isDir: false,
+			})
+		}
+	}
+
+	sort.Sort(ByNameFoldersFirst2(items))
+
+	return items
+}
+
+func (f *ProjFolderItem) isIncluded(path string, includePatterns []string, excludePatterns []string) bool {
+	if len(includePatterns) > 0 {
+		included := false
+		for _, incPat := range includePatterns {
+			if glob.Glob(incPat, path) {
+				included = true
+				break
+			}
+		}
+		if !included {
+			return false
+		}
+	}
+
+	for _, excPat := range excludePatterns {
+		if glob.Glob(excPat, path) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (f *ProjFolderItem) Click() {
+	fmt.Println("Click: ", f.name)
+}
+
+func (f *ProjFolderItem) SetVisible(vis bool) {
+	// fmt.Println("Visible: ", f.name, vis)
+}
+
+func (f *ProjFolderItem) SetExpanded(vis bool) {
+	fmt.Println("Expanded: ", f.name, vis)
+}

--- a/main/projitem.go
+++ b/main/projitem.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/limetext/backend"
+)
+
+type ProjectItem struct {
+	TreeListItemImpl
+
+	Project *backend.Project
+}
+
+var _ TreeListItem = &ProjectItem{}
+
+func (f *ProjectItem) Text() string {
+	return ""
+}
+
+func (f *ProjectItem) Type() string {
+	return "project"
+}
+
+func (f *ProjectItem) Icon() string {
+	return ""
+}
+
+func (f *ProjectItem) HasChildren() bool {
+	return true
+}
+
+func (f *ProjectItem) Children() []TreeListItem {
+	folderPaths := f.Project.Folders()
+	folders := make([]*backend.Folder, len(folderPaths))
+	for i, p := range folderPaths {
+		folders[i] = f.Project.Folder(p)
+	}
+
+	items := make([]TreeListItem, len(folders))
+	store := make([]ProjFolderItem, len(folders))
+	for i, fx := range folders {
+		name := fx.Name
+		if name == "" {
+			name = filepath.Base(fx.Path)
+		}
+		store[i] = ProjFolderItem{
+			path:       fx.Path,
+			name:       name,
+			projFolder: fx,
+		}
+		items[i] = &store[i]
+	}
+
+	sort.Sort(ByNameFoldersFirst2(items)) // items pointers won't change
+
+	return items
+}
+
+func (f *ProjectItem) Click() {
+	// fmt.Println("Click: ", f.name)
+}
+
+func (f *ProjectItem) SetVisible(vis bool) {
+	// fmt.Println("Visible: ", f.name, vis)
+}
+
+func (f *ProjectItem) SetExpanded(vis bool) {
+	// fmt.Println("Expanded: ", f.name, vis)
+}

--- a/main/qml/Sidebar.qml
+++ b/main/qml/Sidebar.qml
@@ -1,0 +1,190 @@
+import QtQuick 2.0
+import QtQuick.Controls 1.0
+import QtQuick.Controls.Styles 1.0
+import QtQuick.Dialogs 1.0
+import QtQuick.Layouts 1.0
+import QtGraphicalEffects 1.0
+
+Rectangle {
+  id: sidebarRoot
+  color: frontend.defaultBg()
+
+  property var sidebarTree
+
+  ListView {
+    id: listView
+
+    anchors.fill: parent
+    model: sidebarTree.model
+    focus: true
+    interactive: false
+    // keyNavigationEnabled: true
+    highlightFollowsCurrentItem: false
+
+    highlight: Rectangle {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      y: listView.currentItem.y
+      height: listView.currentItem.height
+      color: "lightsteelblue"
+    }
+
+    add: Transition {
+      id: addTrans
+      SequentialAnimation {
+        PropertyAction { property: "opacity"; value: 0 }
+        PauseAnimation {
+            duration: 25 //(dispTrans.ViewTransition.index -
+                    // dispTrans.ViewTransition.targetIndexes[0]) * 10
+        }
+        ParallelAnimation {
+          NumberAnimation { property: "opacity"; from: 0; to: 1.0; duration: 100 }
+          NumberAnimation { properties: "x"; from: addTrans.ViewTransition.destination.x-100; duration: 100 }
+        }
+      }
+    }
+
+    remove: Transition {
+        NumberAnimation { property: "opacity"; from: 1.0; to: 0; duration: 100 }
+        NumberAnimation { properties: "x"; to: addTrans.ViewTransition.destination.x+100; duration: 100 }
+    }
+
+    // displaced: Transition {
+    //     NumberAnimation { properties: "x,y"; duration: 400; easing.type: Easing.OutBounce }
+    // }
+
+    addDisplaced: Transition {
+        id: addDispTrans
+        SequentialAnimation {
+            PauseAnimation {
+                duration: 0 //(dispTrans.ViewTransition.index -
+                        // dispTrans.ViewTransition.targetIndexes[0]) * 10
+            }
+            NumberAnimation { properties: "x,y"; duration: 50 }
+        }
+    }
+
+    removeDisplaced: Transition {
+        id: rmDispTrans
+        SequentialAnimation {
+            PauseAnimation {
+                duration: 25 //(dispTrans.ViewTransition.index -
+                        // dispTrans.ViewTransition.targetIndexes[0]) * 10
+            }
+            NumberAnimation { properties: "x,y"; duration: 50 }
+        }
+    }
+
+    delegate: MouseArea {
+      width: parent.width
+      height: childrenRect.height
+      onClicked: {
+        display.item.click()
+        listView.currentIndex = index;
+      }
+
+      RowLayout {
+        spacing: 0
+
+        // Component.onCompleted: {
+        //   console.log("completed: ", index, display, display.item.name())
+        // }
+
+        Item {
+          // indent
+          height: 2
+          width: display.indent * 20
+        }
+        Item {
+          id: expandoHolder
+          Layout.fillHeight: true
+          Layout.topMargin: 2
+          Layout.bottomMargin: 2
+          Layout.preferredWidth: expandoImg.width
+
+          Image {
+            id: expandoImg
+            height: parent.height
+            width: 100
+            source: themeFolder + (display.expanded? "/fold-open@2x.png" : "/fold-closed@2x.png")
+            visible: status != Image.Ready || display.item.hasChildren()
+            fillMode: Image.PreserveAspectFit
+
+            // without this, width has a binding loop
+            onPaintedWidthChanged: {
+              if (paintedWidth > 0)
+                width = paintedWidth;
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              onClicked: {
+                if (display.expanded) {
+                  sidebarTree.collapseNode(index)
+                } else {
+                  sidebarTree.expandNode(index)
+                }
+              }
+            }
+          }
+        }
+        Item {
+          id: iconHolder
+          Layout.fillHeight: true
+          Layout.topMargin: 2
+          Layout.bottomMargin: 2
+          Layout.preferredWidth: iconImg.width
+
+          Image {
+            id: iconImg
+            height: parent.height
+            width: 100
+            source: themeFolder + (display.expanded? "/folder-open@2x.png" : "/folder-closed@2x.png")
+            visible: status != Image.Ready || display.item.hasChildren()
+            fillMode: Image.PreserveAspectFit
+
+            // without this, width has a binding loop
+            onPaintedWidthChanged: {
+              if (paintedWidth > 0)
+                width = paintedWidth;
+            }
+          }
+        }
+        // Rectangle {
+        //   id: icon
+        //   color: "green"
+        //   width: 15
+        //   height: 15
+        // }
+        Text {
+          text: display.item.text()
+          color: "white"
+        }
+      }
+    }
+    MouseArea {
+      anchors.fill: parent
+      property var point: new Object()
+
+      x: 0
+      y: 0
+      // cursorShape: parent.cursor
+      propagateComposedEvents: true
+
+      onWheel: {
+          var delta = wheel.pixelDelta,
+              scaleFactor = 30;
+
+          if (delta.x == 0 && delta.y == 0) {
+              delta = wheel.angleDelta;
+              scaleFactor = 15;
+          }
+
+          scaleFactor /= 3;
+
+          listView.flick(delta.x*scaleFactor, delta.y*scaleFactor);
+          wheel.accepted = true;
+      }
+    }
+  }
+}

--- a/main/qml/Sidebar.qml
+++ b/main/qml/Sidebar.qml
@@ -15,7 +15,7 @@ Rectangle {
     id: listView
 
     anchors.fill: parent
-    model: sidebarTree.model
+    model: sidebarTree && sidebarTree.model
     focus: true
     interactive: false
     // keyNavigationEnabled: true

--- a/main/qml/Window.qml
+++ b/main/qml/Window.qml
@@ -177,7 +177,7 @@ ApplicationWindow {
                 Sidebar {
                   id: sidebarView
                   width: 200
-                  sidebarTree: myWindow.sidebarTree
+                  sidebarTree: myWindow && myWindow.sidebarTree
                 }
                 MainView {
                   id: mainView

--- a/main/qml/Window.qml
+++ b/main/qml/Window.qml
@@ -11,6 +11,10 @@ ApplicationWindow {
     height: 600
     title: "Lime"
 
+    Component.onCompleted: {
+      Qt.application.name = "LimeTextQML"
+    }
+
     property var myWindow
     property string themeFolder: "../../packages/Soda/Soda Dark"
 
@@ -167,8 +171,18 @@ ApplicationWindow {
         SplitView {
             anchors.fill: parent
             orientation: Qt.Vertical
-            MainView {
-                id: mainView
+            SplitView {
+                anchors.fill: parent
+                orientation: Qt.Horizontal
+                Sidebar {
+                  id: sidebarView
+                  width: 200
+                  sidebarTree: myWindow.sidebarTree
+                }
+                MainView {
+                  id: mainView
+                  Layout.fillWidth: true
+                }
             }
             View {
                 id: consoleView
@@ -179,6 +193,7 @@ ApplicationWindow {
             }
         }
     }
+
 
     statusBar: StatusBar {
         id: statusBar
@@ -226,6 +241,7 @@ ApplicationWindow {
             }
         }
     }
+
 
     MessageDialog {
         objectName: "messageDialog"

--- a/main/treelistmodel.go
+++ b/main/treelistmodel.go
@@ -100,12 +100,16 @@ func (i *TreeListItemImpl) SetExpanded(bool) {
 }
 
 type TreeListModel struct {
-	roots []TreeListItem
-	nodes []*treeListNode
+	roots []*treeListRoot
 
 	Model qml.ItemModel
 	qml.ItemModelDefaultImpl
 	internal qml.ItemModelInternal
+}
+
+type treeListRoot struct {
+	rootItem TreeListItem
+	nodes    []*treeListNode
 }
 
 var _ qml.ItemModelImpl = &TreeListModel{}
@@ -115,38 +119,86 @@ type treeListNode struct {
 	Expanded    bool
 	Item        TreeListItem
 	parent      *treeListNode
+	root        *treeListRoot
 	myChildren  int
 	allChildren int
 	model       *TreeListModel
 }
 
-func NewTreeListModel(engine *qml.Engine, parent qml.Object, roots []TreeListItem) *TreeListModel {
-	t := &TreeListModel{
-		roots: roots,
+func NewTreeListModel(engine *qml.Engine, parent qml.Object, rootItems []TreeListItem) *TreeListModel {
+	t := &TreeListModel{}
+
+	roots := make([]*treeListRoot, len(rootItems))
+	for i, item := range rootItems {
+		roots[i] = t.mkRoot(item)
 	}
 
-	t.nodes = t.mkNodes(roots, 0)
+	t.roots = roots
 
 	t.Model, t.internal = qml.NewItemModel(engine, parent, t)
 
-	for _, node := range t.nodes {
-		node.Item.SetVisible(true)
+	for _, r := range t.roots {
+		for _, node := range r.nodes {
+			node.Item.SetVisible(true)
+		}
 	}
 
 	return t
 }
 
-func (t *TreeListModel) mkNodes(items []TreeListItem, indent int) []*treeListNode {
+func (t *TreeListModel) mkRoot(item TreeListItem) *treeListRoot {
+	root := &treeListRoot{
+		rootItem: item,
+	}
+	var items []TreeListItem
+	if !item.HasChildren() {
+		items = []TreeListItem{item}
+	} else {
+		item.SetExpanded(true)
+		items = item.Children()
+		// fmt.Println("rootChildren:", items)
+	}
+	root.nodes = t.mkNodes(items, 0, nil, root)
+
+	return root
+}
+
+func (t *TreeListModel) mkNodes(items []TreeListItem, indent int, parent *treeListNode, root *treeListRoot) []*treeListNode {
 	nodes := make([]*treeListNode, len(items))
 
 	store := make([]treeListNode, len(items))
 	for i, r := range items {
 		store[i].Item = r
 		store[i].Indent = indent
+		store[i].parent = parent
+		store[i].root = root
 		nodes[i] = &store[i]
 	}
 
 	return nodes
+}
+
+func (t *TreeListModel) indexOfRoot(root *treeListRoot) int {
+	indexSoFar := 0
+	for _, r := range t.roots {
+		if r == root {
+			return indexSoFar
+		}
+		indexSoFar += len(r.nodes)
+	}
+	return -1
+}
+
+// rootForIndex takes a global index, and returns a root plus the index relative to that root
+func (t *TreeListModel) rootAndIndex(gindex int) (root *treeListRoot, relIndex int) {
+	indexSoFar := 0
+	for _, r := range t.roots {
+		if gindex < indexSoFar+len(r.nodes) {
+			return r, gindex - indexSoFar
+		}
+		indexSoFar += len(r.nodes)
+	}
+	return nil, -1
 }
 
 func (t *TreeListModel) insertNodes(nodes []*treeListNode, index int, parent *treeListNode) {
@@ -159,12 +211,15 @@ func (t *TreeListModel) insertNodes(nodes []*treeListNode, index int, parent *tr
 		p = p.parent
 	}
 
+	root := parent.root
+	rootIndex := t.indexOfRoot(root)
+
 	// the inner append here likely creates a new slice
 	// a faster way would be to extend the t.nodes if necessary
 	// copy nodes after index to the end and copy nodes into the right place
 	qml.RunMain(func() {
-		t.internal.BeginInsertRows(nil, index, index+numNodes-1)
-		t.nodes = append(t.nodes[:index], append(nodes, t.nodes[index:]...)...)
+		t.internal.BeginInsertRows(nil, rootIndex+index, rootIndex+index+numNodes-1)
+		root.nodes = append(root.nodes[:index], append(nodes, root.nodes[index:]...)...)
 		t.internal.EndInsertRows()
 	})
 
@@ -183,19 +238,22 @@ func (t *TreeListModel) removeNodes(index, length int, parent *treeListNode) {
 		p = p.parent
 	}
 
-	for _, node := range t.nodes[index : index+length] {
+	root := parent.root
+	rootIndex := t.indexOfRoot(root)
+
+	for _, node := range root.nodes[index : index+length] {
 		node.Item.impl().node = nil
 		node.Item.SetVisible(false)
 	}
 
 	qml.RunMain(func() {
-		t.internal.BeginRemoveRows(nil, index, index+length-1)
-		nodesLen := len(t.nodes)
-		copy(t.nodes[index:], t.nodes[index+length:])
-		for k, n := nodesLen-length, nodesLen; k < n; k++ {
-			t.nodes[k] = nil // clear pointers at the end of the array for GC
+		t.internal.BeginRemoveRows(nil, rootIndex+index, rootIndex+index+length-1)
+		nodesLen := len(root.nodes)
+		copy(root.nodes[index:], root.nodes[index+length:])
+		for k := nodesLen - length; k < nodesLen; k++ {
+			root.nodes[k] = nil // clear pointers at the end of the array for GC
 		}
-		t.nodes = t.nodes[:nodesLen-length]
+		root.nodes = root.nodes[:nodesLen-length]
 		t.internal.EndRemoveRows()
 	})
 }
@@ -205,14 +263,16 @@ func (t *TreeListModel) insertChild(parent *treeListNode, item TreeListItem, ind
 		return
 	}
 
+	root := parent.root
+
 	idx := t.findIndex(parent)
 	idx += 1 // children
 	for i := 0; i < index; i++ {
-		idx += t.nodes[idx].allChildren
+		idx += root.nodes[idx].allChildren
 	}
 	// idx is now the index where the new node should go
 
-	nodes := t.mkNodes([]TreeListItem{item}, parent.Indent+1)
+	nodes := t.mkNodes([]TreeListItem{item}, parent.Indent+1, parent, root)
 	t.insertNodes(nodes, idx, parent)
 }
 
@@ -225,10 +285,12 @@ func (t *TreeListModel) removeChild(parent *treeListNode, index int) {
 		panic(fmt.Sprintf("child index (%v) > parent's children (%v)", index, parent.myChildren))
 	}
 
+	root := parent.root
+
 	idx := t.findIndex(parent)
 	idx += 1 // children
 	for i := 0; i < index; i++ {
-		idx += t.nodes[idx].allChildren
+		idx += root.nodes[idx].allChildren
 	}
 	// idx is now the index of the child to remove
 
@@ -247,11 +309,12 @@ func (t *TreeListModel) FindIndex(item TreeListItem) int {
 
 func (t *TreeListModel) findIndex(node *treeListNode) int {
 	idx := 0
+	root := node.root
 	n := node
 	p := node.parent
 	if p != nil {
 		idx = t.findIndex(n.parent)
-		if t.nodes[idx].Expanded == false {
+		if root.nodes[idx].Expanded == false {
 			panic("Parent node is not expanded?")
 		}
 		if idx == -1 {
@@ -262,10 +325,10 @@ func (t *TreeListModel) findIndex(node *treeListNode) int {
 	}
 
 	for {
-		if idx >= len(t.nodes) {
+		if idx >= len(root.nodes) {
 			return -1
 		}
-		item := t.nodes[idx]
+		item := root.nodes[idx]
 		if item.parent != node.parent {
 			panic("item.parent != node.parent!")
 		}
@@ -276,21 +339,27 @@ func (t *TreeListModel) findIndex(node *treeListNode) int {
 	}
 }
 
-func (t *TreeListModel) ExpandNode(index int) {
-	node := t.nodes[index]
+func (t *TreeListModel) ExpandNode(gindex int) {
+	root, index := t.rootAndIndex(gindex)
+
+	node := root.nodes[index]
 	if !node.Item.HasChildren() {
 		return
 	}
 	children := node.Item.Children()
-	childNodes := t.mkNodes(children, node.Indent+1)
+	childNodes := t.mkNodes(children, node.Indent+1, node, root)
 	node.Expanded = true
+	node.Item.SetExpanded(true)
 	qml.Changed(node, &node.Expanded)
 	t.insertNodes(childNodes, index+1, node)
 }
 
-func (t *TreeListModel) CollapseNode(index int) {
-	node := t.nodes[index]
+func (t *TreeListModel) CollapseNode(gindex int) {
+	root, index := t.rootAndIndex(gindex)
+
+	node := root.nodes[index]
 	node.Expanded = false
+	node.Item.SetExpanded(false)
 	qml.Changed(node, &node.Expanded)
 	t.removeNodes(index+1, node.allChildren, node)
 }
@@ -298,16 +367,27 @@ func (t *TreeListModel) CollapseNode(index int) {
 //ItemModelImpl
 
 func (t *TreeListModel) RowCount(parent qml.ModelIndex) int {
-	return len(t.nodes)
+	count := 0
+	for _, r := range t.roots {
+		count += len(r.nodes)
+	}
+	// fmt.Println("rowcount: ", count)
+	return count
 }
 
-func (t *TreeListModel) Data(index qml.ModelIndex, role qml.Role) interface{} {
-	row := index.Row()
-	return t.nodes[row]
+func (t *TreeListModel) Data(mindex qml.ModelIndex, role qml.Role) interface{} {
+	row := mindex.Row()
+	root, index := t.rootAndIndex(row)
+	// fmt.Println("data: ", row, root, index, root.nodes[index])
+	return root.nodes[index]
 }
 
 func (t *TreeListModel) Index(row int, column int, parent qml.ModelIndex) qml.ModelIndex {
-	if !parent.IsValid() && column == 0 && row >= 0 && row < len(t.nodes) {
+	if !parent.IsValid() && column == 0 && row >= 0 {
+		root, _ := t.rootAndIndex(row)
+		if root == nil {
+			return nil
+		}
 		return t.internal.CreateIndex(row, column, 0)
 	}
 	return nil

--- a/main/treelistmodel.go
+++ b/main/treelistmodel.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/limetext/qml-go"
+)
+
+// TreeListItem must include the TreeListItemImpl as an embedded struct
+//     type MyItem struct {
+//         TreeListItemImpl
+//     }
+// TreeListItemImpl includes do-nothing implementations for all functions except
+// Text() and Click() to make implementations easier
+//
+type TreeListItem interface {
+	// Text returns the text to display
+	Text() string
+
+	// Type for rendering e.g. "file" or "header"
+	Type() string
+
+	Icon() string
+
+	// HasChildren should return if an expando arrow should appear
+	HasChildren() bool
+
+	// Children is only called when expanding the item
+	Children() []TreeListItem
+
+	// InsertChild is to be called when the children of this item changes, externally
+	// to the tree list model. It will not do anything if the node is not expanded.
+	InsertChild(item TreeListItem, index int)
+
+	// RemoveChild is to be called when the children of this item changes, externally
+	// to the tree list model. It will not do anything if the node is not expanded.
+	RemoveChild(index int)
+
+	// Click is called when the user selects the item
+	Click()
+
+	// SetVisible is called when the item is shown or hidden.
+	SetVisible(bool)
+
+	// SetExpanded is called when an item is expanded and its children are shown.
+	// It can be used to add or remove watchers for its children.
+	SetExpanded(bool)
+
+	impl() *TreeListItemImpl
+}
+
+type TreeListItemImpl struct {
+	node *treeListNode
+}
+
+func (impl *TreeListItemImpl) impl() *TreeListItemImpl {
+	return impl
+}
+
+// Type for rendering e.g. "file" or "header"
+func (i *TreeListItemImpl) Type() string {
+	return "item"
+}
+
+func (i *TreeListItemImpl) Icon() string {
+	return ""
+}
+
+// HasChildren should return if an expando arrow should appear
+func (i *TreeListItemImpl) HasChildren() bool {
+	return false
+}
+
+// Children is only called when expanding the item
+func (i *TreeListItemImpl) Children() []TreeListItem {
+	return nil
+}
+
+// InsertChild is to be called when the children of this item changes, externally
+// to the tree list model. It will not do anything if the node is not expanded.
+func (i *TreeListItemImpl) InsertChild(item TreeListItem, index int) {
+	i.node.model.insertChild(i.node, item, index)
+}
+
+// RemoveChild is to be called when the children of this item changes, externally
+// to the tree list model. It will not do anything if the node is not expanded.
+func (i *TreeListItemImpl) RemoveChild(index int) {
+	i.node.model.removeChild(i.node, index)
+}
+
+// SetVisible is called when the item is shown or hidden.
+func (i *TreeListItemImpl) SetVisible(bool) {
+
+}
+
+// SetExpanded is called when an item is expanded and its children are shown.
+// It can be used to add or remove watchers for its children.
+func (i *TreeListItemImpl) SetExpanded(bool) {
+
+}
+
+type TreeListModel struct {
+	roots []TreeListItem
+	nodes []*treeListNode
+
+	Model qml.ItemModel
+	qml.ItemModelDefaultImpl
+	internal qml.ItemModelInternal
+}
+
+var _ qml.ItemModelImpl = &TreeListModel{}
+
+type treeListNode struct {
+	Indent      int
+	Expanded    bool
+	Item        TreeListItem
+	parent      *treeListNode
+	myChildren  int
+	allChildren int
+	model       *TreeListModel
+}
+
+func NewTreeListModel(engine *qml.Engine, parent qml.Object, roots []TreeListItem) *TreeListModel {
+	t := &TreeListModel{
+		roots: roots,
+	}
+
+	t.nodes = t.mkNodes(roots, 0)
+
+	t.Model, t.internal = qml.NewItemModel(engine, parent, t)
+
+	for _, node := range t.nodes {
+		node.Item.SetVisible(true)
+	}
+
+	return t
+}
+
+func (t *TreeListModel) mkNodes(items []TreeListItem, indent int) []*treeListNode {
+	nodes := make([]*treeListNode, len(items))
+
+	store := make([]treeListNode, len(items))
+	for i, r := range items {
+		store[i].Item = r
+		store[i].Indent = indent
+		nodes[i] = &store[i]
+	}
+
+	return nodes
+}
+
+func (t *TreeListModel) insertNodes(nodes []*treeListNode, index int, parent *treeListNode) {
+	numNodes := len(nodes)
+	parent.myChildren += numNodes
+
+	p := parent
+	for p != nil {
+		p.allChildren += numNodes
+		p = p.parent
+	}
+
+	// the inner append here likely creates a new slice
+	// a faster way would be to extend the t.nodes if necessary
+	// copy nodes after index to the end and copy nodes into the right place
+	qml.RunMain(func() {
+		t.internal.BeginInsertRows(nil, index, index+numNodes-1)
+		t.nodes = append(t.nodes[:index], append(nodes, t.nodes[index:]...)...)
+		t.internal.EndInsertRows()
+	})
+
+	for _, node := range nodes {
+		node.Item.impl().node = node
+		node.Item.SetVisible(true)
+	}
+}
+
+func (t *TreeListModel) removeNodes(index, length int, parent *treeListNode) {
+	parent.myChildren -= length
+
+	p := parent
+	for p != nil {
+		p.allChildren -= length
+		p = p.parent
+	}
+
+	for _, node := range t.nodes[index : index+length] {
+		node.Item.impl().node = nil
+		node.Item.SetVisible(false)
+	}
+
+	qml.RunMain(func() {
+		t.internal.BeginRemoveRows(nil, index, index+length-1)
+		nodesLen := len(t.nodes)
+		copy(t.nodes[index:], t.nodes[index+length:])
+		for k, n := nodesLen-length, nodesLen; k < n; k++ {
+			t.nodes[k] = nil // clear pointers at the end of the array for GC
+		}
+		t.nodes = t.nodes[:nodesLen-length]
+		t.internal.EndRemoveRows()
+	})
+}
+
+func (t *TreeListModel) insertChild(parent *treeListNode, item TreeListItem, index int) {
+	if !parent.Expanded {
+		return
+	}
+
+	idx := t.findIndex(parent)
+	idx += 1 // children
+	for i := 0; i < index; i++ {
+		idx += t.nodes[idx].allChildren
+	}
+	// idx is now the index where the new node should go
+
+	nodes := t.mkNodes([]TreeListItem{item}, parent.Indent+1)
+	t.insertNodes(nodes, idx, parent)
+}
+
+func (t *TreeListModel) removeChild(parent *treeListNode, index int) {
+	if !parent.Expanded {
+		return
+	}
+
+	if index >= parent.myChildren {
+		panic(fmt.Sprintf("child index (%v) > parent's children (%v)", index, parent.myChildren))
+	}
+
+	idx := t.findIndex(parent)
+	idx += 1 // children
+	for i := 0; i < index; i++ {
+		idx += t.nodes[idx].allChildren
+	}
+	// idx is now the index of the child to remove
+
+	t.removeNodes(idx, 1, parent)
+}
+
+// FindIndex returns the absolute index of the item in the currently visible list,
+// or -1 if it is not currently visible.
+func (t *TreeListModel) FindIndex(item TreeListItem) int {
+	impl := item.impl()
+	if impl == nil {
+		return -1
+	}
+	return t.findIndex(impl.node)
+}
+
+func (t *TreeListModel) findIndex(node *treeListNode) int {
+	idx := 0
+	n := node
+	p := node.parent
+	if p != nil {
+		idx = t.findIndex(n.parent)
+		if t.nodes[idx].Expanded == false {
+			panic("Parent node is not expanded?")
+		}
+		if idx == -1 {
+			return -1
+		}
+	} else {
+		// probably one of the roots. If not, it is not in the tree!
+	}
+
+	for {
+		if idx >= len(t.nodes) {
+			return -1
+		}
+		item := t.nodes[idx]
+		if item.parent != node.parent {
+			panic("item.parent != node.parent!")
+		}
+		if node == item {
+			return idx
+		}
+		idx += item.allChildren
+	}
+}
+
+func (t *TreeListModel) ExpandNode(index int) {
+	node := t.nodes[index]
+	if !node.Item.HasChildren() {
+		return
+	}
+	children := node.Item.Children()
+	childNodes := t.mkNodes(children, node.Indent+1)
+	node.Expanded = true
+	qml.Changed(node, &node.Expanded)
+	t.insertNodes(childNodes, index+1, node)
+}
+
+func (t *TreeListModel) CollapseNode(index int) {
+	node := t.nodes[index]
+	node.Expanded = false
+	qml.Changed(node, &node.Expanded)
+	t.removeNodes(index+1, node.allChildren, node)
+}
+
+//ItemModelImpl
+
+func (t *TreeListModel) RowCount(parent qml.ModelIndex) int {
+	return len(t.nodes)
+}
+
+func (t *TreeListModel) Data(index qml.ModelIndex, role qml.Role) interface{} {
+	row := index.Row()
+	return t.nodes[row]
+}
+
+func (t *TreeListModel) Index(row int, column int, parent qml.ModelIndex) qml.ModelIndex {
+	if !parent.IsValid() && column == 0 && row >= 0 && row < len(t.nodes) {
+		return t.internal.CreateIndex(row, column, 0)
+	}
+	return nil
+}

--- a/main/window.go
+++ b/main/window.go
@@ -38,7 +38,7 @@ func (w *window) launch(wg *sync.WaitGroup, component qml.Object) {
 
 	root := &FSTreeItem{path: filepath.Dir(me)}
 
-	w.SidebarTree = NewTreeListModel(component.Common().Engine(), nil, root.Children())
+	w.SidebarTree = NewTreeListModel(component.Common().Engine(), nil, []TreeListItem{root})
 
 	w.qw = component.CreateWindow(nil)
 	w.qw.Show()

--- a/main/window.go
+++ b/main/window.go
@@ -5,8 +5,6 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/limetext/backend"
@@ -34,11 +32,15 @@ func newWindow(bw *backend.Window) *window {
 func (w *window) launch(wg *sync.WaitGroup, component qml.Object) {
 	wg.Add(1)
 
-	me, _ := filepath.Abs(os.Args[0])
+	project := w.Back().OpenProject("testproj.sublime-project")
 
-	root := &FSTreeItem{path: filepath.Dir(me)}
+	// me, _ := filepath.Abs(os.Args[0])
 
-	w.SidebarTree = NewTreeListModel(component.Common().Engine(), nil, []TreeListItem{root})
+	filesHeader := &HeaderItem{name: "files"}
+	// root := &FSTreeItem{path: filepath.Dir(me), isDir: true}
+	proj := &ProjectItem{Project: project}
+
+	w.SidebarTree = NewTreeListModel(component.Common().Engine(), nil, []TreeListItem{filesHeader, proj})
 
 	w.qw = component.CreateWindow(nil)
 	w.qw.Show()

--- a/main/window.go
+++ b/main/window.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/limetext/backend"
@@ -13,9 +15,10 @@ import (
 
 // A helper glue structure connecting the backend Window with the qml.Window
 type window struct {
-	bw    *backend.Window
-	qw    *qml.Window
-	views map[*backend.View]*view
+	bw          *backend.Window
+	qw          *qml.Window
+	views       map[*backend.View]*view
+	SidebarTree *TreeListModel
 }
 
 func newWindow(bw *backend.Window) *window {
@@ -30,6 +33,13 @@ func newWindow(bw *backend.Window) *window {
 // once the window closes.
 func (w *window) launch(wg *sync.WaitGroup, component qml.Object) {
 	wg.Add(1)
+
+	me, _ := filepath.Abs(os.Args[0])
+
+	root := &FSTreeItem{path: filepath.Dir(me)}
+
+	w.SidebarTree = NewTreeListModel(component.Common().Engine(), nil, root.Children())
+
 	w.qw = component.CreateWindow(nil)
 	w.qw.Show()
 	w.qw.Set("myWindow", w)


### PR DESCRIPTION
This is just a work-in-progress to track the sidebar.

The sidebar here is pretty generic. It should be pretty easy to refactor this code to support multiple sidebars with different kinds of items from different sources.

Here's what's left to be done:
- [x] Use project folder list
- [x] Filter files by include/exclude globs
- [ ] Move filesystem sidebar stuff to backend
- [ ] Handle clicking on files: open them!
- [x] Top level should be children of roots, not roots themselves

As far as moving things to backend, I'm thinking the only thing that should be moved to the backend is https://github.com/limetext/lime-qml/blob/sidebar/main/fstreeitem.go, but I'm not yet sure that the interface it uses is complete enough to be used in the backend. Moving the tree flattening list manager thing to the backend could be nice, but it would be tricky because the QML code needs to know when items are inserted into or removed from the list, and they need to know both before and after that happens.
