### PR TITLE
Unhardcode icon file type for GNU/Linux launcher

### DIFF
--- a/main/qml/org.limetext.qml.LimeText.desktop
+++ b/main/qml/org.limetext.qml.LimeText.desktop
@@ -5,5 +5,5 @@ Name=LimeText
 Comment=Lime Text code editor
 TryExec=main
 Exec=main %F
-Icon=lime.png
+Icon=lime
 MimeType=image/x-foo;


### PR DESCRIPTION
Since you're going to install the icon to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) (I take it that way, otherwise you'd have to specify the full path) you don't need to specify the icon file extension in the `.desktop` launcher. It will be found anyway.

This facilitates the use of non-PNG (e.g. SVG) app icon themes.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example).
